### PR TITLE
Enable PR auto-merge and branch cleanup

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -4,9 +4,16 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - closed
 
 jobs:
   verify:
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -38,6 +45,7 @@ jobs:
       contents: read
       pull-requests: write
     if: >
+      github.event.action != 'closed' &&
       github.event.pull_request.draft == false &&
       github.event.pull_request.base.ref == 'main'
     steps:
@@ -46,3 +54,34 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           merge-method: squash
+
+  delete_branch:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    if: |
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Delete merged branch
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const branch = context.payload.pull_request.head.ref;
+            if (branch && branch !== context.payload.pull_request.base.ref) {
+              try {
+                await github.rest.git.deleteRef({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: `heads/${branch}`,
+                });
+              } catch (error) {
+                if (![404, 422].includes(error.status)) {
+                  throw error;
+                }
+              }
+            }


### PR DESCRIPTION
## Summary
- ensure the PR validation workflow listens for additional pull request events so auto-merge is only enabled after a successful build
- add a job that deletes merged branches from this repository once the pull request is closed and merged

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e5bb541fd483338f9f7dc5934f3414